### PR TITLE
test case for long URLs: fails

### DIFF
--- a/src/RequestContext.js
+++ b/src/RequestContext.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+const {parse} = require('url');
 const utils = require('./utils.js');
 
 /**
@@ -22,7 +23,7 @@ module.exports = class RequestContext {
     const { url } = req;
     this._cfg = cfg || {};
     this._url = url;
-    this._path = url || '/';
+    this._path = parse(url).pathname || '/'; //get the path name without query string
     this._selector = '';
     this._extension = '';
     this._headers = req.headers || {};

--- a/src/RequestContext.js
+++ b/src/RequestContext.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const {parse} = require('url');
+const { parse } = require('url');
 const utils = require('./utils.js');
 
 /**
@@ -23,7 +23,7 @@ module.exports = class RequestContext {
     const { url } = req;
     this._cfg = cfg || {};
     this._url = url;
-    this._path = parse(url).pathname || '/'; //get the path name without query string
+    this._path = parse(url).pathname || '/'; // get the path name without query string
     this._selector = '';
     this._extension = '';
     this._headers = req.headers || {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,7 @@ const utils = {
   async fetch(uri, logger) {
     if (uri.charAt(0) === '/') {
       try {
-        return await fs.readFile(uri);
+        return await fs.readFile(uri.replace(/\?.*$/, ''));
       } catch (e) {
         if (e.code === 'ENOENT') {
           return null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,15 +30,15 @@ const utils = {
   },
 
   /**
-   * Fetches content from the given uri.
-   * @param {String} uri Either filesystem path (starting with '/') or URL
+   * Fetches content from the given uri or path.
+   * @param {String} uriOrPath Either filesystem path (starting with '/') or URL
    * @param {Logger} the logger
    * @returns {*} The requested content or NULL if not exists.
    */
-  async fetch(uri, logger) {
-    if (uri.charAt(0) === '/') {
+  async fetch(uriOrPath, logger) {
+    if (uriOrPath.charAt(0) === '/') {
       try {
-        return await fs.readFile(uri.replace(/\?.*$/, ''));
+        return await fs.readFile(uriOrPath.replace(/\?.*$/, ''));
       } catch (e) {
         if (e.code === 'ENOENT') {
           return null;
@@ -49,7 +49,7 @@ const utils = {
     try {
       const response = await request({
         method: 'GET',
-        uri,
+        uriOrPath,
         resolveWithFullResponse: true,
         encoding: null,
       });
@@ -57,11 +57,11 @@ const utils = {
     } catch (e) {
       if (e.response && e.response.statusCode) {
         if (e.response.statusCode !== 404) {
-          logger.error(`resource at ${uri} does not exist. got ${e.response.statusCode} from server`);
+          logger.error(`resource at ${uriOrPath} does not exist. got ${e.response.statusCode} from server`);
         }
         return null;
       }
-      logger.error(`resource at ${uri} does not exist. ${e.message}`);
+      logger.error(`resource at ${uriOrPath} does not exist. ${e.message}`);
       return null;
     }
   },
@@ -72,15 +72,15 @@ const utils = {
    * @return {Promise} A promise that resolves to the request context.
    */
   async fetchStatic(ctx) {
-    const uris = [
+    const uriOrPaths = [
       ctx.config.contentRepo.raw + ctx.path,
       path.resolve(ctx.config.webRootDir, ctx.path.substring(1)),
     ];
-    for (let i = 0; i < uris.length; i += 1) {
-      const uri = uris[i];
-      ctx.logger.debug(`fetching static resource from ${uri}`);
+    for (let i = 0; i < uriOrPaths.length; i += 1) {
+      const uriOrPath = uriOrPaths[i];
+      ctx.logger.debug(`fetching static resource from ${uriOrPath}`);
       // eslint-disable-next-line no-await-in-loop
-      const data = await utils.fetch(uri, ctx.logger);
+      const data = await utils.fetch(uriOrPath, ctx.logger);
       if (data != null) {
         ctx.content = Buffer.from(data, 'utf8');
         return ctx;

--- a/test/hlx_server_test.js
+++ b/test/hlx_server_test.js
@@ -122,7 +122,7 @@ describe('Helix Server', () => {
     }
   });
 
-  it('deliver rendered resource with long URL', async (done) => {
+  it('deliver rendered resource with long URL', async () => {
     const cwd = path.join(SPEC_ROOT, 'local');
     const project = new HelixProject()
       .withCwd(cwd)
@@ -132,9 +132,6 @@ describe('Helix Server', () => {
     try {
       await project.start();
       await assertHttp(`http://localhost:${project.server.port}/index.html?xxxxxxxxx=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&xxxxxxxxxxxx=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&xxxxxx=xxxxxxxx|xxxxxxx|xxxxxxxx&xxxxxxxxxxxxx=xxxxx%xxxx|xxxxx%xxxxxxxxx%xxxxxxxxxxxx|xxxxx-xx-xxxxxxxxx-xxxx`, 200, 'expected_index.html');
-      done();
-    } catch (e) {
-      done(e);
     } finally {
       await project.stop();
     }

--- a/test/hlx_server_test.js
+++ b/test/hlx_server_test.js
@@ -122,6 +122,24 @@ describe('Helix Server', () => {
     }
   });
 
+  it('deliver rendered resource with long URL', async (done) => {
+    const cwd = path.join(SPEC_ROOT, 'local');
+    const project = new HelixProject()
+      .withCwd(cwd)
+      .withBuildDir('./build')
+      .withHttpPort(0);
+    await project.init();
+    try {
+      await project.start();
+      await assertHttp(`http://localhost:${project.server.port}/index.html?xxxxxxxxx=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&xxxxxxxxxxxx=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx&xxxxxx=xxxxxxxx|xxxxxxx|xxxxxxxx&xxxxxxxxxxxxx=xxxxx%xxxx|xxxxx%xxxxxxxxx%xxxxxxxxxxxx|xxxxx-xx-xxxxxxxxx-xxxx`, 200, 'expected_index.html');
+      done();
+    } catch (e) {
+      done(e);
+    } finally {
+      await project.stop();
+    }
+  });
+
   it('deliver rendered json resource', async () => {
     const cwd = path.join(SPEC_ROOT, 'local');
     const project = new HelixProject()


### PR DESCRIPTION
I've encountered an error in local simulation when working with long URLs (generated by an OAuth dance). `hlx up` will fail with an error message: 

```
Error: ENAMETOOLONG: name too long, open '/Users/hireshah/helix-6/analytics.html?client_id=5a8d…
```

This PR introduces a test case for Helix Simulator that reproduces that error and fixes it.

Fixes #102 