### PR TITLE
fix(package): The repository has moved URL

### DIFF
--- a/test/specs/remote/helix-config.yaml
+++ b/test/specs/remote/helix-config.yaml
@@ -16,5 +16,5 @@ definitions:
 strains:
   default:
     code: *localRepo
-    content: https://github.com/Adobe-Marketing-Cloud/reactor-user-docs.git
+    content: https://github.com/adobe/reactor-user-docs.git
     static: *localRepo


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The package.json file is currently pointed to `Adobe-Marketing-Cloud`, the repository now currently lives at `adobe`.
<!--- Describe your changes in detail -->
## Types of changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [✓] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [✓] I have read the **CONTRIBUTING** document.
