### PR TITLE
fix(params): assign action/body and querystring to params

### DIFF
--- a/src/HelixServer.js
+++ b/src/HelixServer.js
@@ -80,9 +80,6 @@ async function executeTemplate(ctx) {
     __ow_headers: owHeaders,
     __ow_method: ctx.method.toLowerCase(),
     __ow_logger: ctx.logger,
-    owner: ctx.strain.content.owner,
-    repo: ctx.strain.content.repo,
-    ref: ctx.strain.content.ref || 'master',
     path: `${ctx.resourcePath}.md`,
     selector: ctx._selector,
     extension: ctx._extension,
@@ -93,9 +90,18 @@ async function executeTemplate(ctx) {
 
   Object.assign(actionParams, ctx.actionParams, ctx.body);
   if (ctx.url.match(/^\/cgi-bin\//)) {
-    Object.assign(actionParams, ctx._params);
+    Object.assign(actionParams, {
+      __hlx_owner: ctx.strain.content.owner,
+      __hlx_repo: ctx.strain.content.repo,
+      __hlx_ref: ctx.strain.content.ref || 'master',
+    }, ctx._params);
   } else {
-    actionParams.params = querystring.stringify(ctx._params);
+    Object.assign(actionParams, {
+      owner: ctx.strain.content.owner,
+      repo: ctx.strain.content.repo,
+      ref: ctx.strain.content.ref || 'master',
+      params: querystring.stringify(ctx._params),
+    });
   }
   return Promise.resolve(mod.main(actionParams));
   /* eslint-enable no-underscore-dangle */

--- a/src/HelixServer.js
+++ b/src/HelixServer.js
@@ -80,8 +80,6 @@ async function executeTemplate(ctx) {
     __ow_headers: owHeaders,
     __ow_method: ctx.method.toLowerCase(),
     __ow_logger: ctx.logger,
-    REPO_RAW_ROOT: `${ctx.strain.content.rawRoot}/`, // the pipeline needs the final slash here
-    REPO_API_ROOT: `${ctx.strain.content.apiRoot}/`,
   };
 
   Object.assign(actionParams, ctx.actionParams, ctx.body);
@@ -101,6 +99,8 @@ async function executeTemplate(ctx) {
       extension: ctx._extension,
       rootPath: ctx._mount,
       params: querystring.stringify(ctx._params),
+      REPO_RAW_ROOT: `${ctx.strain.content.rawRoot}/`, // the pipeline needs the final slash here
+      REPO_API_ROOT: `${ctx.strain.content.apiRoot}/`,
     });
   }
   return Promise.resolve(mod.main(actionParams));

--- a/src/HelixServer.js
+++ b/src/HelixServer.js
@@ -80,10 +80,6 @@ async function executeTemplate(ctx) {
     __ow_headers: owHeaders,
     __ow_method: ctx.method.toLowerCase(),
     __ow_logger: ctx.logger,
-    path: `${ctx.resourcePath}.md`,
-    selector: ctx._selector,
-    extension: ctx._extension,
-    rootPath: ctx._mount,
     REPO_RAW_ROOT: `${ctx.strain.content.rawRoot}/`, // the pipeline needs the final slash here
     REPO_API_ROOT: `${ctx.strain.content.apiRoot}/`,
   };
@@ -100,6 +96,10 @@ async function executeTemplate(ctx) {
       owner: ctx.strain.content.owner,
       repo: ctx.strain.content.repo,
       ref: ctx.strain.content.ref || 'master',
+      path: `${ctx.resourcePath}.md`,
+      selector: ctx._selector,
+      extension: ctx._extension,
+      rootPath: ctx._mount,
       params: querystring.stringify(ctx._params),
     });
   }

--- a/src/HelixServer.js
+++ b/src/HelixServer.js
@@ -87,23 +87,13 @@ async function executeTemplate(ctx) {
     selector: ctx._selector,
     extension: ctx._extension,
     rootPath: ctx._mount,
+    // Keep next line this for backward compatibility?
     params: querystring.stringify(ctx._params),
     REPO_RAW_ROOT: `${ctx.strain.content.rawRoot}/`, // the pipeline needs the final slash here
     REPO_API_ROOT: `${ctx.strain.content.apiRoot}/`,
   };
 
-  if (ctx.body) {
-    // add post params to action params
-    Object.keys(ctx.body).forEach((key) => {
-      actionParams[key] = ctx.body[key];
-    });
-  }
-  if (ctx.actionParams) {
-    // add argument action params
-    Object.keys(ctx.actionParams).forEach((key) => {
-      actionParams[key] = ctx.actionParams[key];
-    });
-  }
+  Object.assign(actionParams, ctx.actionParams, ctx.body, ctx._params);
   return Promise.resolve(mod.main(actionParams));
   /* eslint-enable no-underscore-dangle */
 }

--- a/src/HelixServer.js
+++ b/src/HelixServer.js
@@ -87,13 +87,16 @@ async function executeTemplate(ctx) {
     selector: ctx._selector,
     extension: ctx._extension,
     rootPath: ctx._mount,
-    // Keep next line this for backward compatibility?
-    params: querystring.stringify(ctx._params),
     REPO_RAW_ROOT: `${ctx.strain.content.rawRoot}/`, // the pipeline needs the final slash here
     REPO_API_ROOT: `${ctx.strain.content.apiRoot}/`,
   };
 
-  Object.assign(actionParams, ctx.actionParams, ctx.body, ctx._params);
+  Object.assign(actionParams, ctx.actionParams, ctx.body);
+  if (ctx.url.match(/^\/cgi-bin\//)) {
+    Object.assign(actionParams, ctx._params);
+  } else {
+    actionParams.params = querystring.stringify(ctx._params);
+  }
   return Promise.resolve(mod.main(actionParams));
   /* eslint-enable no-underscore-dangle */
 }


### PR DESCRIPTION
fix #378 

Changed the order of evaluating actions (as it happens in OpenWhisk):
   **query string** params _win over_ **body** params _win over_ **action** params